### PR TITLE
fix: kill_on_drop on firebird, mariadb, mysql, redis, valkey

### DIFF
--- a/src/domain/firebird/ping.rs
+++ b/src/domain/firebird/ping.rs
@@ -20,6 +20,7 @@ pub async fn run(cfg: DatabaseConfig) -> anyhow::Result<bool> {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn()?;
 
     let query = b"SELECT 1 FROM RDB$DATABASE;\nQUIT;\n";

--- a/src/domain/mariadb/ping.rs
+++ b/src/domain/mariadb/ping.rs
@@ -12,7 +12,8 @@ pub async fn run(cfg: DatabaseConfig, env: HashMap<String, String>) -> anyhow::R
         .arg("--user")
         .arg(cfg.username)
         .arg("ping")
-        .envs(env);
+        .envs(env)
+        .kill_on_drop(true);
 
     let result = timeout(Duration::from_secs(10), cmd.output()).await;
 

--- a/src/domain/mysql/ping.rs
+++ b/src/domain/mysql/ping.rs
@@ -12,7 +12,8 @@ pub async fn run(cfg: DatabaseConfig, env: HashMap<String, String>) -> anyhow::R
         .arg("--user")
         .arg(cfg.username)
         .arg("ping")
-        .envs(env);
+        .envs(env)
+        .kill_on_drop(true);
 
     let result = timeout(Duration::from_secs(10), cmd.output()).await;
 

--- a/src/domain/redis/ping.rs
+++ b/src/domain/redis/ping.rs
@@ -21,6 +21,8 @@ pub async fn run(cfg: DatabaseConfig) -> Result<bool> {
 
     cmd.arg("PING");
 
+    cmd.kill_on_drop(true);
+
     debug!("Command Ping Redis: {:?}", cmd);
 
     let result = timeout(Duration::from_secs(10), cmd.output()).await;

--- a/src/domain/valkey/ping.rs
+++ b/src/domain/valkey/ping.rs
@@ -20,6 +20,7 @@ pub async fn run(cfg: DatabaseConfig) -> Result<bool> {
     }
 
     cmd.arg("PING");
+    cmd.kill_on_drop(true);
 
     debug!("Command Ping Valkey: {:?}", cmd);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of database and cache health checks by automatically terminating background ping processes when checks are cancelled or abandoned.
  * Prevents lingering Firebird, MySQL, MariaDB, Redis, and Valkey processes from consuming resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->